### PR TITLE
Better Voting messages for adding/removing time

### DIFF
--- a/core/Modules/Votes/Votes.php
+++ b/core/Modules/Votes/Votes.php
@@ -242,8 +242,9 @@ class Votes extends Module implements ModuleInterface
                 return;
             }
         }
-
-        $question = 'Add $<' . secondary(round($secondsToAdd / 60, 1)) . '$> minutes?';
+        
+        $verb = $secondsToAdd>0 ? 'Add' : 'Subtract';
+        $question = $verb . ' $<' . secondary(abs(round($secondsToAdd / 60, 1))) . '$> minutes?';
 
         $voteStarted = self::startVote($player, $question, function ($success) use ($secondsToAdd, $question) {
             if ($success) {


### PR DESCRIPTION
Commands like `/time -1` result in a voting message like `Add -1 minutes?`. Most people don't read the whole message and just the "Add", causing them to vote `No` even if they want to subtract time. With this change those messages become "Subtract 1 minutes?". It's clearer.

WARNING: Didn't test the code, cause I don't have a TM server and haven't coded in PHP in a long time.