### PR TITLE
Fix User Agent Header for Windows and legacy OSX newline encodings

### DIFF
--- a/core/global-functions.php
+++ b/core/global-functions.php
@@ -18,7 +18,7 @@ require 'vendor/larapack/dd/src/helper.php';
  */
 function getEvoSCVersion(): string
 {
-    return str_replace("\n", '', file_get_contents(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'VERSION'));
+    return str_replace(["\r\n","\r" ,"\n"], '', file_get_contents(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'VERSION'));
 }
 
 /**


### PR DESCRIPTION
Replace windows (\r\n) and osx (\r) style newline encoding for the user agent of the rest client.

On Windows systems and legacy osx systems this would cause exceptions when trying to fetch information about maps or when trying to add maps from Trackmania Exchange. This is caused by the Mania Exchange or Trackmania Exchange Servers not accepting newlines in the User Agent Header of the Request. So far only unix style newlines were removed, so that the rest client received an 400 Bad Request HTTP Error.

Fixes #127