### PR TITLE
Adding a ChatCommand explaining what a speeddrift is

### DIFF
--- a/core/Modules/FunCommands/FunCommands.php
+++ b/core/Modules/FunCommands/FunCommands.php
@@ -35,6 +35,13 @@ class FunCommands extends Module implements ModuleInterface
             infoMessage($player, ' boots back to the real world!')->sendAll();
             Server::kick($player->Login, 'cya');
         }, 'Boot yourself back to the real world.');
+        
+        ChatCommand::add('/sd', function (Player $player) {
+            infoMessage('A speeddrift (SD) is a drift during which all 4 tires produce drift marks,' . 
+                        'with the front and rear marks overlapping on each side.'. '
+                        A SD can be initiated at over 400km/h by either oversteering, driving over a bump/jump or tapping the break.')->send($player);
+            Server::kick($player->Login, 'cya');
+        }, 'Learn what a SpeedDrift (SD) is.');
 
         ChatCommand::add('/me', function (Player $player, ...$message) {
             array_shift($message);

--- a/core/Modules/FunCommands/FunCommands.php
+++ b/core/Modules/FunCommands/FunCommands.php
@@ -39,7 +39,7 @@ class FunCommands extends Module implements ModuleInterface
         ChatCommand::add('/sd', function (Player $player) {
             infoMessage('A speeddrift (SD) is a drift during which all 4 tires produce drift marks,' . 
                         'with the front and rear marks overlapping on each side.'. '
-                        A SD can be initiated at over 400km/h by either oversteering, driving over a bump/jump or tapping the break.')->send($player);
+                        A SD can be initiated at over 400km/h by either oversteering, driving over a bump/jump or tapping the brake.')->send($player);
             Server::kick($player->Login, 'cya');
         }, 'Learn what a SpeedDrift (SD) is.');
 


### PR DESCRIPTION
Sometimes players on the FS Beg 2020 server ask what a speeddrift is and I often answer them, but that takes time.

That's why I propose introducing this `/sd` command, which will tell the player that invoked it what a speed drift is.