### PR TITLE
Fix map folder selection compativility with TMX Map Download

### DIFF
--- a/core/Modules/MxDownload/MxDownload.php
+++ b/core/Modules/MxDownload/MxDownload.php
@@ -113,7 +113,7 @@ class MxDownload extends Module implements ModuleInterface
         $filename = html_entity_decode(trim($filename), ENT_QUOTES | ENT_HTML5);
         $filename = preg_replace('/[^a-z0-9\-_# .]/i', '', $filename);
         $filename = preg_replace('/\s/i', '_', $filename);
-        $filename = "MX/$mxId" . "_$filename";
+        $filename = "MX" . DIRECTORY_SEPARATOR . "$mxId" . "_$filename";
 
         Log::write('Saving map as ' . MapController::getMapsPath($filename), true);
         File::put(MapController::getMapsPath($filename), $download->getBody()->getContents());
@@ -176,6 +176,7 @@ class MxDownload extends Module implements ModuleInterface
             'name' => $gbx->Name,
             'environment' => $gbx->Environment,
             'title_id' => $gbx->TitleId,
+            'folder' => substr($filename, 0, strrpos($filename, DIRECTORY_SEPARATOR)),
             'enabled' => 1,
             'cooldown' => config('server.map-cooldown', 10),
             'mx_id' => $mxId,

--- a/core/Modules/MxPacks/Classes/MxPackJob.php
+++ b/core/Modules/MxPacks/Classes/MxPackJob.php
@@ -117,7 +117,7 @@ class MxPackJob
         ]);
 
         $zip = new ZipArchive();
-        $dir = $this->packsDir . '/' . $this->name;
+        $dir = $this->packsDir . DIRECTORY_SEPARATOR . $this->name;
 
         if (is_dir($dir)) {
             File::delete($dir);
@@ -153,7 +153,7 @@ class MxPackJob
 
             preg_match($pattern, $name, $matches);
             $mx_id = $matches[1];
-            $filename = 'MXPacks/' . $this->name . '/' . $name;
+            $filename = 'MXPacks'. DIRECTORY_SEPARATOR . $this->name . DIRECTORY_SEPARATOR . $name;
 
             $gbx = MapController::getGbxInformation($filename, false);
             $uid = $gbx->MapUid;
@@ -183,6 +183,7 @@ class MxPackJob
                 Map::create([
                     'uid'         => $uid,
                     'filename'    => $filename,
+                    'folder'      => 'MXPacks'.DIRECTORY_SEPARATOR. $this->name,
                     'author'      => $authorId,
                     'mx_id'       => $mx_id,
                     'enabled'     => 1,


### PR DESCRIPTION
Fixed Trackmania Exchange MapPack Download compatibility with map folder selection. The recent implementation of the trackmania exchange and the folder map selection UI caused new Trackmania Exchange downloads to fail.