### PR TITLE
Added windows alternative to shutdown evosc on linux using signals

### DIFF
--- a/core/Commands/EscRunSignal.php
+++ b/core/Commands/EscRunSignal.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EvoSC\Commands;
+
+use EvoSC\Commands\EscRun;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
+
+class EscRunSignal extends EscRun implements SignalableCommandInterface {
+    /**
+     * Returns the signals which EvoSC subscribes to
+     *
+     * @return array
+     */
+    public function getSubscribedSignals(): array
+    {
+        // return here any of the constants defined by PCNTL extension
+        // https://www.php.net/manual/en/pcntl.constants.php
+        return [SIGTERM];
+    }
+
+    /**
+     * Signal handler
+     *
+     * @param int $signal
+     */
+    public function handleSignal(int $signal): void
+    {
+        if ($signal == SIGTERM) {
+            $this->shutdownEvoSC();
+        }
+    }
+}

--- a/esc
+++ b/esc
@@ -3,6 +3,7 @@
 require 'vendor/autoload.php';
 require 'core/global-functions.php';
 
+use EvoSC\Commands\EscRunSignal;
 use EvoSC\Commands\LoadAuthorNamesTMX;
 use EvoSC\Commands\GetVersion;
 use EvoSC\Commands\EscRun;
@@ -50,7 +51,7 @@ $application->add(new MakeMigration());
 $application->add(new ImportUaseco());
 $application->add(new ImportPyplanet());
 $application->add(new GetVersion());
-$application->add(new EscRun());
+$application->add(extension_loaded('pcntl') ? new EscRunSignal(): new EscRun());
 $application->add(new FakeLocals());
 $application->add(new AddAdmin());
 $application->add(new SetupAccessRights());


### PR DESCRIPTION
Fixes #156 

I'm trying to work a bit on windows compatibility. This is one of the things that led to the fact that Evosc didn't even start on Windows anymore. Please note this is only a suggestion, there are a lot of different methods to fix this kind of problem, maybe even revert the commit that introduced signals. 