### PR TITLE
Add ext-curl in composer.json requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A modern server controller for the game Trackmania (TM² & 2020).
 
 
 ### Requirements
-* PHP 7.4 and simplexml, mbstring, gd, dom, mysql extension.
+* PHP 7.4 and simplexml, mbstring, gd, dom, mysql, curl extension.
 * Composer
 * MySQL/MariaDB Server
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   ],
   "require": {
     "php": "^7.4",
+    "ext-curl": "*",
     "ext-json": "*",
     "ext-simplexml": "*",
     "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97fb5d5a2af3c30fab2dfe459c3a13d2",
+    "content-hash": "c1f43dfd9d0f6492cc9bb7baa5979d85",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -209,12 +209,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -271,12 +271,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -467,12 +467,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
                 "files": [
                     "helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -748,12 +748,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
                 "files": [
                     "helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -936,12 +936,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "League\\Csv\\": "src"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1803,12 +1803,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1882,12 +1882,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1965,12 +1965,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2050,12 +2050,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2137,12 +2137,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2214,12 +2214,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2290,12 +2290,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2369,12 +2369,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2602,12 +2602,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -3081,9 +3081,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -3091,12 +3088,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3896,11 +3893,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5019,11 +5016,12 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.4",
+        "ext-curl": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
         "ext-mbstring": "*",
         "ext-zip": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
The PHP Curl extension is required for EvoSC to work, but this dependency is not mentioned in the `composer.json` file

<details>
  <summary>Logs when starting EvoSC without the curl extension</summary>

  ```
Executing migrations...
Nothing to migrate.
Connecting to server...
Connection established.
      ______           _____ ______
     / ____/  _______ / ___// ____/
    / __/| | / / __ \__ \/ /
   / /___| |/ / /_/ /__/ / /___
  /_____/|___/\____/____/\____/  0.99.78

[18:01:19] EscRun->execute(): Starting...
[18:01:19] Database::init(): Connecting to database...
[18:01:19] Database::init(): Database connected.
[18:01:19] TemplateController::loadTemplates(): Loading templates...
[18:01:19] ChatController::init(): Chat router started.
[18:01:19] MapController::loadMaps(): Loading maps
...
[18:01:20] ModuleController::startModules(): Starting modules...
........................................................
[18:01:20] ModuleController::startModules(): Starting modules finished. 56 modules started.
PHP Warning:  Use of undefined constant CURLOPT_CUSTOMREQUEST - assumed 'CURLOPT_CUSTOMREQUEST' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 210
PHP Warning:  Use of undefined constant CURLOPT_URL - assumed 'CURLOPT_URL' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 211
PHP Warning:  Use of undefined constant CURLOPT_RETURNTRANSFER - assumed 'CURLOPT_RETURNTRANSFER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 212
PHP Warning:  Use of undefined constant CURLOPT_HEADER - assumed 'CURLOPT_HEADER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 213
PHP Warning:  Use of undefined constant CURLOPT_CONNECTTIMEOUT - assumed 'CURLOPT_CONNECTTIMEOUT' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 214
PHP Warning:  Use of undefined constant CURLOPT_HTTP_VERSION - assumed 'CURLOPT_HTTP_VERSION' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 223
PHP Warning:  Use of undefined constant CURL_HTTP_VERSION_1_1 - assumed 'CURL_HTTP_VERSION_1_1' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 223
PHP Warning:  Use of undefined constant CURLOPT_SSL_VERIFYHOST - assumed 'CURLOPT_SSL_VERIFYHOST' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 347
PHP Warning:  Use of undefined constant CURLOPT_SSL_VERIFYPEER - assumed 'CURLOPT_SSL_VERIFYPEER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 348
PHP Warning:  Use of undefined constant CURLOPT_CAINFO - assumed 'CURLOPT_CAINFO' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 362
PHP Warning:  Use of undefined constant CURLOPT_ENCODING - assumed 'CURLOPT_ENCODING' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 373
PHP Warning:  Use of undefined constant CURLOPT_HTTPHEADER - assumed 'CURLOPT_HTTPHEADER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 375
PHP Warning:  Use of undefined constant CURLOPT_FILE - assumed 'CURLOPT_FILE' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 399
PHP Warning:  Use of undefined constant CURLOPT_FILE - assumed 'CURLOPT_FILE' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 400
PHP Warning:  Use of undefined constant CURLOPT_TIMEOUT_MS - assumed 'CURLOPT_TIMEOUT_MS' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 405
PHP Warning:  Use of undefined constant CURLOPT_HTTPHEADER - assumed 'CURLOPT_HTTPHEADER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 311
PHP Warning:  Use of undefined constant CURLOPT_HTTPHEADER - assumed 'CURLOPT_HTTPHEADER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 311
PHP Warning:  Use of undefined constant CURLOPT_HTTPHEADER - assumed 'CURLOPT_HTTPHEADER' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 318
PHP Warning:  Use of undefined constant CURLOPT_HEADERFUNCTION - assumed 'CURLOPT_HEADERFUNCTION' (this will throw an Error in a future version of PHP) in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 55
PHP Fatal error:  Uncaught Error: Call to undefined function GuzzleHttp\Handler\curl_init() in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:58
Stack trace:
#0 /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php(83): GuzzleHttp\Handler\CurlFactory->create()
#1 /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php(37): GuzzleHttp\Handler\CurlMultiHandler->__invoke()
#2 /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Middleware.php(29): GuzzleHttp\PrepareBodyMiddleware->__invoke()
#3 /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php(70): GuzzleHttp\Middleware::GuzzleHttp\{closure}()
#4 /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Middleware.php(59): GuzzleHttp\RedirectMiddleware->__invoke()
#5 /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/HandlerStack.php(71): GuzzleHttp\Middleware::GuzzleHttp\{closure}()
#6 /home/emile/servers/test/EvoSC/vendor/guzzl in /home/emile/servers/test/EvoSC/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 58
  ```

</details>

I suggest to add this dependency to the `composer.json` file to inform users that this extension is required when they try to configure EvoSC:

<details>
  <summary>Error triggered when running <code>composer install</code> without the curl extension</summary>  

  ```
emile@localhost:~/servers/test/EvoSC$ composer i --no-dev
> php core/required_directories.php
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - Root composer.json requires PHP extension ext-curl * but it is missing from your system. Install or enable PHP's curl extension.

To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php/7.4/cli/php.ini
    - /etc/php/7.4/cli/conf.d/10-mysqlnd.ini
    - /etc/php/7.4/cli/conf.d/10-opcache.ini
    - /etc/php/7.4/cli/conf.d/10-pdo.ini
    - /etc/php/7.4/cli/conf.d/15-xml.ini
    - /etc/php/7.4/cli/conf.d/20-calendar.ini
    - /etc/php/7.4/cli/conf.d/20-ctype.ini
    - /etc/php/7.4/cli/conf.d/20-dom.ini
    - /etc/php/7.4/cli/conf.d/20-exif.ini
    - /etc/php/7.4/cli/conf.d/20-ffi.ini
    - /etc/php/7.4/cli/conf.d/20-fileinfo.ini
    - /etc/php/7.4/cli/conf.d/20-ftp.ini
    - /etc/php/7.4/cli/conf.d/20-gd.ini
    - /etc/php/7.4/cli/conf.d/20-gettext.ini
    - /etc/php/7.4/cli/conf.d/20-iconv.ini
    - /etc/php/7.4/cli/conf.d/20-json.ini
    - /etc/php/7.4/cli/conf.d/20-mbstring.ini
    - /etc/php/7.4/cli/conf.d/20-mysqli.ini
    - /etc/php/7.4/cli/conf.d/20-pdo_mysql.ini
    - /etc/php/7.4/cli/conf.d/20-phar.ini
    - /etc/php/7.4/cli/conf.d/20-posix.ini
    - /etc/php/7.4/cli/conf.d/20-readline.ini
    - /etc/php/7.4/cli/conf.d/20-shmop.ini
    - /etc/php/7.4/cli/conf.d/20-simplexml.ini
    - /etc/php/7.4/cli/conf.d/20-sockets.ini
    - /etc/php/7.4/cli/conf.d/20-sysvmsg.ini
    - /etc/php/7.4/cli/conf.d/20-sysvsem.ini
    - /etc/php/7.4/cli/conf.d/20-sysvshm.ini
    - /etc/php/7.4/cli/conf.d/20-tokenizer.ini
    - /etc/php/7.4/cli/conf.d/20-xmlreader.ini
    - /etc/php/7.4/cli/conf.d/20-xmlwriter.ini
    - /etc/php/7.4/cli/conf.d/20-xsl.ini
    - /etc/php/7.4/cli/conf.d/20-zip.ini
You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
Alternatively, you can run Composer with `--ignore-platform-req=ext-curl` to temporarily ignore these required extensions.
  ```
</details>
