### PR TITLE
Fix SIGINT not handled by EscRunSignal when using pcntl

### DIFF
--- a/core/Commands/EscRunSignal.php
+++ b/core/Commands/EscRunSignal.php
@@ -15,7 +15,7 @@ class EscRunSignal extends EscRun implements SignalableCommandInterface {
     {
         // return here any of the constants defined by PCNTL extension
         // https://www.php.net/manual/en/pcntl.constants.php
-        return [SIGTERM];
+        return [SIGTERM, SIGINT];
     }
 
     /**
@@ -25,7 +25,7 @@ class EscRunSignal extends EscRun implements SignalableCommandInterface {
      */
     public function handleSignal(int $signal): void
     {
-        if ($signal == SIGTERM) {
+        if ($signal == SIGTERM || $signal == SIGINT) {
             $this->shutdownEvoSC();
         }
     }


### PR DESCRIPTION
When using the pcntl module, a different class is used which handles the system signals to shut down evosc. However it was forgotten to add support for SIGINT, making it impossible to close the process through the terminal as an example. This pull request adds a subscription to SIGINT as well.